### PR TITLE
Fix typo in method name

### DIFF
--- a/config.go
+++ b/config.go
@@ -60,7 +60,14 @@ type GroupsConfigs struct {
 }
 
 // Appends attributes to params in client config file.
+//
+// Deprecated: Use AppendUsersAttributes() instead. Will be removed soon.
 func (cfg *Config) AppendUsesAttributes(attrs ...string) {
+	cfg.AppendUsersAttributes(attrs...)
+}
+
+// Appends attributes to params in client config file.
+func (cfg *Config) AppendUsersAttributes(attrs ...string) {
 	cfg.Users.Attributes = append(cfg.Users.Attributes, attrs...)
 }
 

--- a/examples/custom_attributes.go
+++ b/examples/custom_attributes.go
@@ -24,7 +24,7 @@ func mainCustomAttributes() {
 
 	// Append custom user attributes to all searches and get it.
 
-	cl.Config.AppendUsesAttributes("manager")
+	cl.Config.AppendUsersAttributes("manager")
 
 	user, err := cl.GetUser(adc.GetUserArgs{
 		Id: "exampleUserId",

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -8,17 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_AppendUsesAttributes(t *testing.T) {
+func Test_AppendUsersAttributes(t *testing.T) {
 	cfg := &adc.Config{
 		Users: &adc.UsersConfigs{
 			Attributes: []string{"one"},
 		},
 	}
 
-	cfg.AppendUsesAttributes()
+	cfg.AppendUsersAttributes()
 	require.Equal(t, []string{"one"}, cfg.Users.Attributes)
 
-	cfg.AppendUsesAttributes("two")
+	cfg.AppendUsersAttributes("two")
 	require.Equal(t, []string{"one", "two"}, cfg.Users.Attributes)
 }
 


### PR DESCRIPTION
Hi @dlampsi, thank you for your library!

Probably, there is a typo in method name `config.AppendUsesAttributes()` (should be **Users**, I suppose). 
